### PR TITLE
Fixes #3

### DIFF
--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -39,7 +39,7 @@ syn match ledgerComment /^;.*$/
 " comments at eol must be preceeded by at least 2 spaces / 1 tab
 syn region ledgerMetadata start=/\%(  \|\t\|^\s\+\);/ skip=/^\s\+;/ end=/^/
     \ keepend contained contains=ledgerTag,ledgerTypedTag
-syn match ledgerTag /:[^:]\+:/hs=s+1,he=e-1 contained
+syn match ledgerTag /\(^\s\+;\s*\)\@<=[^:]\+:/hs=s,he=e-1 contained
 syn match ledgerTag /\%(\%(;\|^tag\)[^:]\+\)\@<=[^:]\+:\ze[^:]\+$/ contained
 syn match ledgerTypedTag /\%(\%(;\|^tag\)[^:]\+\)\@<=[^:]\+::\ze[^:]\+$/ contained
 


### PR DESCRIPTION
Only the first text after the comment up through the colon will be highlighted as a tag, the rest of the line is still considered a comment. Tested on a complex ledger file with ~14000 lines with no slowdown, so the look-behind added to the regular expression doesn't impact performance.
