### PR TITLE
Do not alter global options (fillchars).

### DIFF
--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -13,8 +13,6 @@ let b:undo_ftplugin = "setlocal ".
                     \ "foldmethod< foldtext< ".
                     \ "include< comments< commentstring< omnifunc< formatprg<"
 
-" don't fill fold lines --> cleaner look
-setl fillchars="fold: "
 setl foldtext=LedgerFoldText()
 setl foldmethod=syntax
 setl include=^!include


### PR DESCRIPTION
Fillchars is a global-only option (`:h fillchars`). A plugin should not override global settings.