### PR TITLE
Fix bug where completion includes following accounts.

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -297,8 +297,8 @@ function! ledger#find_in_tree(tree, levels)
   let currentlvl = a:levels[0]
   let nextlvls = a:levels[1:]
   let branches = ledger#filter_items(keys(a:tree), currentlvl)
-  let exact = empty(nextlvls)
   for branch in branches
+    let exact = empty(nextlvls)
     call add(results, [branch, exact])
     if ! empty(nextlvls)
       for [result, exact] in ledger#find_in_tree(a:tree[branch], nextlvls)


### PR DESCRIPTION
Suppose we have the ledger file below:

2015/07/16 payee
  act1:liabilities:card1   $15
  expenses:misc

2015/07/16 payee2
  act2:liabilities:card2   $15
  expenses:misc

When completing "a:li:card1", the completion function will return both
"act1:liabilities:card1" and "act2". The account "act2" is included because it
is using the exact value from the previous "act1:liabilities:card1" match.