### PR TITLE
Reports and reconciling

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -401,3 +401,19 @@ func! ledger#entry()
   normal "_dd
   exec l . 'read !' g:ledger_bin '-f' shellescape(expand('%')) 'entry' shellescape(query)
 endfunc
+
+function! s:error_message(msg)
+  redraw  " See h:echo-redraw
+  echohl ErrorMsg
+  echo "\r"
+  echomsg a:msg
+  echohl NONE
+endf
+
+function! s:warning_message(msg)
+  redraw  " See h:echo-redraw
+  echohl WarningMsg
+  echo "\r"
+  echomsg a:msg
+  echohl NONE
+endf

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -503,14 +503,6 @@ function! s:ledger_cmd(arglist)
   endfor
   return l:cmd
 endf
-
-function! s:is_ledger_buffer()
-  if getbufvar(winbufnr(winnr()), "&ft") !=# "ledger"
-    call s:error_message("Please switch to a Ledger buffer first.")
-    return 0
-  endif
-  return 1
-endf
 " }}}
 
 " Run an arbitrary ledger command and show the output in a new buffer. If
@@ -520,7 +512,6 @@ endf
 " Parameters:
 " args  A string of Ledger command-line arguments.
 function! ledger#report(args)
-  if !s:is_ledger_buffer() | return | endif
   let l:output = systemlist(s:ledger_cmd(split(a:args)))
   if v:shell_error  " If there are errors, show them in a quickfix/location list.
     call s:quickfix_populate(l:output)
@@ -550,7 +541,6 @@ endf
 " Parameters:
 " args  A string of Ledger command-line arguments.
 function! ledger#register(args)
-  if !s:is_ledger_buffer() | return | endif
   let l:cmd = s:ledger_cmd(extend([
         \ "register",
         \ "--format='" . g:ledger_qf_register_format . "'",

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -399,7 +399,7 @@ func! ledger#entry()
   let l = line('.') - 1 " Insert transaction at the current line (i.e., below the line above the current one)
   let query = getline('.')
   normal "_dd
-  exec l . 'read !' g:ledger_bin '-f' shellescape(expand('%')) 'entry' shellescape(query)
+  exec l . 'read !' g:ledger_bin '-f' shellescape(expand(g:ledger_main)) 'entry' shellescape(query)
 endfunc
 
 " Report generation {{{1

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -446,6 +446,9 @@ function! s:quickfix_toggle(...)
 
   if l:open
     execute (g:ledger_qf_vertical ? 'vert' : 'botright') l:list.'open' g:ledger_qf_size
+    " Set local mappings to quit the quickfix window  or lose focus.
+    nnoremap <silent> <buffer> <tab> <c-w><c-w>
+    execute 'nnoremap <silent> <buffer> q :' l:list.'close<CR>'
     " Note that the following settings do not persist (e.g., when you close and re-open the quickfix window).
     " See: http://superuser.com/questions/356912/how-do-i-change-the-quickix-title-status-bar-in-vim
     if g:ledger_qf_hide_file

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -555,6 +555,10 @@ endf
 " Reconcile the given account.
 " This function accepts a file path as a third optional argument.
 " The default is to use the value of g:ledger_main.
+"
+" Parameters:
+" account  An account name (String)
+" target_amount The target amount (Float)
 function! ledger#reconcile(account, target_amount, ...)
   let l:file = (a:0 > 0 ? a:1 : g:ledger_main)
   let l:cmd = s:ledger_cmd([
@@ -578,7 +582,7 @@ function! ledger#reconcile(account, target_amount, ...)
     augroup END
     " Add refresh shortcut
     execute "nnoremap <silent> <buffer> <c-l> :<c-u>call ledger#reconcile('"
-          \ . a:account . "'," . a:target_amount . ",'" . l:file . "')<cr>"
+          \ . a:account . "'," . string(a:target_amount) . ",'" . l:file . "')<cr>"
     " We need to pass the file path explicitly because at this point we are in
     " the quickfix window
     call ledger#show_balance(a:account, l:file)
@@ -644,7 +648,7 @@ function! ledger#show_balance(...)
   if exists('g:ledger_target_amount')
     echon ' ' g:ledger_target_string
     echohl LedgerTarget
-    echon printf('%.2f', (str2float(g:ledger_target_amount) - str2float(l:amounts[2])))
+    echon printf('%.2f', (g:ledger_target_amount - str2float(l:amounts[2])))
     echohl NONE
   endif
 endf

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -572,7 +572,7 @@ function! ledger#reconcile(account, target_amount, ...)
         \ ])
   let l:file = expand(l:file) " Needed for #show_balance() later
   call s:quickfix_populate(systemlist(l:cmd))
-  if s:quickfix_toggle("Reconcile '" . a:account . "' account", "Nothing to reconcile")
+  if s:quickfix_toggle("Reconcile " . a:account, "Nothing to reconcile")
     let g:ledger_target_amount = a:target_amount
     " Show updated account balance upon saving, as long as the quickfix window is open
     augroup reconcile

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -513,17 +513,15 @@ function! s:is_ledger_buffer()
 endf
 " }}}
 
-" Run an arbitrary ledger command to process the current buffer, and show the
-" output in a new buffer. If there are errors, no new buffer is opened: the
-" errors are displayed in a quickfix window instead.
+" Run an arbitrary ledger command and show the output in a new buffer. If
+" there are errors, no new buffer is opened: the errors are displayed in a
+" quickfix window instead.
 "
 " Parameters:
-" args  A string of Ledger arguments.
+" args  A string of Ledger command-line arguments.
 function! ledger#report(args)
   if !s:is_ledger_buffer() | return | endif
-  let l:cmd = s:ledger_cmd(['-f', '%'] + split(a:args, ' '))
-  " Run Ledger
-  let l:output = systemlist(l:cmd)
+  let l:output = systemlist(s:ledger_cmd(split(a:args)))
   if v:shell_error  " If there are errors, show them in a quickfix/location list.
     call s:quickfix_populate(l:output)
     call s:quickfix_toggle('Errors', 'Unable to parse errors')
@@ -547,15 +545,18 @@ function! ledger#report(args)
   syntax match LedgerImproperPerc /\d\d\d\+%/
 endf
 
-" Show a register report in a quickfix list.
+" Show an arbitrary register report in a quickfix list.
+"
+" Parameters:
+" args  A string of Ledger command-line arguments.
 function! ledger#register(args)
   if !s:is_ledger_buffer() | return | endif
   let l:cmd = s:ledger_cmd(extend([
         \ "register",
-        \ "-f", "%",
         \ "--format='" . g:ledger_qf_register_format . "'",
         \ "--prepend-format='%(filename):%(beg_line) '"
-        \ ], split(a:args, ' ')))
+        \ ], split(a:args))
+        \ )
   call s:quickfix_populate(systemlist(l:cmd))
   call s:quickfix_toggle('Register report')
 endf

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -1,3 +1,4 @@
+" vim:ts=2:sw=2:sts=2:foldmethod=marker
 function! ledger#transaction_state_toggle(lnum, ...)
   if a:0 == 1
     let chars = a:1

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -542,7 +542,7 @@ function! ledger#report(args)
   nnoremap <silent> <buffer> <tab> <c-w><c-w>
   nnoremap <silent> <buffer> q <c-w>c
   " Add some coloring to the report
-  syntax match LedgerNumber /[^-]\d\+\([,.]\d\+\)\+/
+  syntax match LedgerNumber /-\@1<!\d\+\([,.]\d\+\)\+/
   syntax match LedgerNegativeNumber /-\d\+\([,.]\d\+\)\+/
   syntax match LedgerImproperPerc /\d\d\d\+%/
 endf

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -493,7 +493,7 @@ endf
 " See also http://vim.wikia.com/wiki/Display_output_of_shell_commands_in_new_window
 " See also https://groups.google.com/forum/#!topic/vim_use/4ZejMpt7TeU
 function! s:ledger_cmd(arglist)
-  let l:cmd = g:ledger_bin
+  let l:cmd = g:ledger_bin . ' ' . g:ledger_extra_options
   for l:part in a:arglist
     if l:part =~ '\v^[%#<]'
       let l:expanded_part = expand(l:part)

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -607,7 +607,7 @@ function! ledger#show_balance(...)
     return
   endif
   let l:cmd = s:ledger_cmd([
-        \ 'cleared',
+        \ "cleared",
         \ l:account,
         \ "--empty",
         \ "--collapse",

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -601,7 +601,7 @@ function! ledger#show_balance(...)
         \ "--empty",
         \ "--collapse",
         \ "--format='%(scrub(get_at(display_total, 0)))|%(scrub(get_at(display_total, 1)))|%(quantity(scrub(get_at(display_total, 1))))'",
-        \ (exists("g:ledger_default_commodity") ? "-X " . g:ledger_default_commodity : '')
+        \ (empty(g:ledger_default_commodity) ? '' : "-X " . shellescape(g:ledger_default_commodity))
         \ ])
   let l:amounts = split(substitute(system(l:cmd), '\%x00', '/', 'g'), '|')
   redraw  " Necessary in some cases to overwrite previous messages. See :h echo-redraw

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -519,7 +519,6 @@ endf
 function! ledger#report(args)
   if !s:is_ledger_buffer() | return | endif
   let l:cmd = s:ledger_cmd(['-f', '%'] + split(a:args, ' '))
-  if g:ledger_debug | return l:cmd | endif
   " Run Ledger
   let l:output = systemlist(l:cmd)
   if v:shell_error  " If there are errors, show them in a quickfix/location list.
@@ -554,7 +553,6 @@ function! ledger#register(args)
         \ "--format='" . g:ledger_qf_register_format . "'",
         \ "--prepend-format='%(filename):%(beg_line) '"
         \ ], split(a:args, ' ')))
-  if g:ledger_debug | return l:cmd | endif
   call s:quickfix_populate(systemlist(l:cmd))
   call s:quickfix_toggle('Register report')
 endf
@@ -568,7 +566,6 @@ function! ledger#reconcile(account, target_amount)
         \ "--format='" . g:ledger_qf_reconcile_format . "'",
         \ "--prepend-format='%(filename):%(beg_line) %(pending ? \"P\" : \"U\") '"
         \ ])
-  if g:ledger_debug | return l:cmd | endif
   call s:quickfix_populate(systemlist(l:cmd))
   if s:quickfix_toggle("Reconcile '" . a:account . "' account", "Nothing to reconcile")
     let g:ledger_target_amount = a:target_amount
@@ -606,7 +603,6 @@ function! ledger#show_balance(...)
         \ "--format='%(scrub(get_at(display_total, 0)))|%(scrub(get_at(display_total, 1)))|%(quantity(scrub(get_at(display_total, 1))))'",
         \ (exists("g:ledger_default_commodity") ? "-X " . g:ledger_default_commodity : '')
         \ ])
-  if g:ledger_debug | return l:cmd | endif
   let l:amounts = split(substitute(system(l:cmd), '\%x00', '/', 'g'), '|')
   redraw  " Necessary in some cases to overwrite previous messages. See :h echo-redraw
   if empty(l:amounts)

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -476,6 +476,7 @@ function! s:quickfix_populate(data)
   set errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
   " Format to parse command-line errors:
   set errorformat+=Error:\ %m
+  " Format to parse reports:
   set errorformat+=%f:%l\ %m
   set errorformat+=%-G%.%#
   execute (g:ledger_use_location_list ? 'l' : 'c').'getexpr' 'a:data'

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -603,7 +603,15 @@ function! ledger#show_balance(...)
         \ "--format='%(scrub(get_at(display_total, 0)))|%(scrub(get_at(display_total, 1)))|%(quantity(scrub(get_at(display_total, 1))))'",
         \ (empty(g:ledger_default_commodity) ? '' : "-X " . shellescape(g:ledger_default_commodity))
         \ ])
-  let l:amounts = split(substitute(system(l:cmd), '\%x00', '/', 'g'), '|')
+  let l:output = systemlist(l:cmd)
+  " Errors may occur, for example,  when the account has multiple commodities
+  " and g:ledger_default_commodity is empty.
+  if v:shell_error
+    call s:quickfix_populate(l:output)
+    call s:quickfix_toggle('Errors', 'Unable to parse errors')
+    return
+  endif
+  let l:amounts = split(l:output[-1], '|')
   redraw  " Necessary in some cases to overwrite previous messages. See :h echo-redraw
   if empty(l:amounts)
     call s:error_message("Could not determine balance. Did you use a valid account?")

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -435,7 +435,7 @@ endf
 " a:2  Message to show when the window is empty.
 "
 " Returns 0 if the quickfix window is empty, 1 otherwise.
-function! s:quickfixToggle(...)
+function! s:quickfix_toggle(...)
   if g:ledger_use_location_list
     let l:list = 'l'
     let l:open = (len(getloclist(winnr())) > 0)
@@ -524,7 +524,7 @@ function! ledger#report(args)
   let l:output = systemlist(l:cmd)
   if v:shell_error  " If there are errors, show them in a quickfix/location list.
     call s:quickfix_populate(l:output)
-    call s:quickfixToggle('Errors', 'Unable to parse errors')
+    call s:quickfix_toggle('Errors', 'Unable to parse errors')
     return
   endif
   if empty(l:output)
@@ -556,7 +556,7 @@ function! ledger#register(args)
         \ ], split(a:args, ' ')))
   if g:ledger_debug | return l:cmd | endif
   call s:quickfix_populate(systemlist(l:cmd))
-  call s:quickfixToggle('Register report')
+  call s:quickfix_toggle('Register report')
 endf
 
 function! ledger#reconcile(account, target_amount)
@@ -570,7 +570,7 @@ function! ledger#reconcile(account, target_amount)
         \ ])
   if g:ledger_debug | return l:cmd | endif
   call s:quickfix_populate(systemlist(l:cmd))
-  if s:quickfixToggle("Reconcile '" . a:account . "' account", "Nothing to reconcile")
+  if s:quickfix_toggle("Reconcile '" . a:account . "' account", "Nothing to reconcile")
     let g:ledger_target_amount = a:target_amount
     " Show updated account balance upon saving, as long as the quickfix window is open
     augroup reconcile

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -473,6 +473,7 @@ function! s:quickfix_populate(data)
   set errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
   " Format to parse command-line errors:
   set errorformat+=Error:\ %m
+  set errorformat+=%f:%l\ %m
   set errorformat+=%-G%.%#
   execute (g:ledger_use_location_list ? 'l' : 'c').'getexpr' 'a:data'
   let &errorformat = l:efm  " Restore global errorformat
@@ -542,4 +543,18 @@ function! ledger#report(args)
   syntax match LedgerNumber /[^-]\d\+\([,.]\d\+\)\+/
   syntax match LedgerNegativeNumber /-\d\+\([,.]\d\+\)\+/
   syntax match LedgerImproperPerc /\d\d\d\+%/
+endf
+
+" Show a register report in a quickfix list.
+function! ledger#register(args)
+  if !s:is_ledger_buffer() | return | endif
+  let l:cmd = s:ledger_cmd(extend([
+        \ "register",
+        \ "-f", "%",
+        \ "--format='" . g:ledger_qf_register_format . "'",
+        \ "--prepend-format='%(filename):%(beg_line) '"
+        \ ], split(a:args, ' ')))
+  if g:ledger_debug | return l:cmd | endif
+  call s:quickfix_populate(systemlist(l:cmd))
+  call s:quickfixToggle('Register report')
 endf

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -449,8 +449,8 @@ function! s:quickfix_toggle(...)
     " Note that the following settings do not persist (e.g., when you close and re-open the quickfix window).
     " See: http://superuser.com/questions/356912/how-do-i-change-the-quickix-title-status-bar-in-vim
     if g:ledger_qf_hide_file
-      set conceallevel=2
-      set concealcursor=nc
+      setl conceallevel=2
+      setl concealcursor=nc
       syntax match qfFile /^[^|]*/ transparent conceal
     endif
     if a:0 > 0

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -576,6 +576,9 @@ function! ledger#reconcile(account, target_amount, ...)
       execute "autocmd BufWritePost *.ldg,*.ledger call ledger#show_balance('" . a:account . "','" . l:file . "')"
       autocmd BufWipeout <buffer> call <sid>finish_reconciling()
     augroup END
+    " Add refresh shortcut
+    execute "nnoremap <silent> <buffer> <c-l> :<c-u>call ledger#reconcile('"
+          \ . a:account . "'," . a:target_amount . ",'" . l:file . "')<cr>"
     " We need to pass the file path explicitly because at this point we are in
     " the quickfix window
     call ledger#show_balance(a:account, l:file)

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -613,7 +613,7 @@ function! ledger#show_balance(...)
   endif
   let l:amounts = split(l:output[-1], '|')
   redraw  " Necessary in some cases to overwrite previous messages. See :h echo-redraw
-  if empty(l:amounts)
+  if len(l:amounts) < 3
     call s:error_message("Could not determine balance. Did you use a valid account?")
     return
   endif

--- a/compiler/ledger.vim
+++ b/compiler/ledger.vim
@@ -13,7 +13,7 @@ if exists(":CompilerSet") != 2
 endif
 
 " default value will be set in ftplugin
-if ! exists("g:ledger_bin") || empty(g:ledger_bin) || ! executable(split(g:ledger_bin, '\s')[0])
+if ! exists("g:ledger_bin") || empty(g:ledger_bin) || ! executable(g:ledger_bin)
   finish
 endif
 
@@ -25,5 +25,5 @@ CompilerSet errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
 CompilerSet errorformat+=%-G%.%#
 
 " Check file syntax
-exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ source\ %:S'
+exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ %:S'
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -155,6 +155,33 @@ REPORTS                                                      *ledger-reports*
   may use the standard quickfix commands to jump from an entry in the register
   report to the corresponding location in the source file.
 
+* :`Reconcile`
+
+  Reconcile an account. For example:
+
+	:Reconcile checking
+
+  After you press Enter, you will be asked to enter a target amount (use
+  Vim's syntax for numbers, not your ledger's format). For example, for a
+  checking account, the target amount may be the balance of your latest bank
+  statement. The list of uncleared postings appears in the quickfix window.
+  The current balance of the account, together with the difference between the
+  target amount and the cleared balance, is shown at the bottom of the screen.
+  You may use standard quickfix commands to navigate through the postings. You
+  may use |ledger#transaction_state_set()| to update a transaction's state.
+  Every time you save your file, the balance and the difference from the
+  target amount are updated at the bottom of the screen. The goal, of course,
+  is to get such difference to zero. To finish reconciling an account, simply
+  close the quickfix window.
+
+  There is a highlight group to customize the color of the difference from
+  target:
+
+  * `LedgerTarget`
+
+    This is used to color the difference between the target amount and the
+    cleared balance.
+
 ==============================================================================
 SETTINGS                                                     *ledger-settings*
 
@@ -227,6 +254,13 @@ behaviour of the ledger filetype.
 
   The format is specified using the standard Ledger syntax for --format.
 
+* Format of the reconcile quickfix window (see |:Reconcile|):
+
+	let g:ledger_qf_reconcile_format = \
+        '%(date) %-4(code) %-50(payee) %-30(account) %15(amount)\n'
+
+  The format is specified using the standard Ledger syntax for --format.
+
 * Flag that tells whether a location list or a quickfix list should be used:
 
 	let g:ledger_use_location_list = 0
@@ -257,6 +291,7 @@ behaviour of the ledger filetype.
 
 	let g:ledger_cleared_string = 'Cleared: '
 	let g:ledger_pending_string = 'Cleared or pending: '
+	let g:ledger_target_string = 'Difference from target: '
 
 * For debugging purposes:
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -124,6 +124,27 @@ REPORTS                                                      *ledger-reports*
 
     This is used to color improper percentages.
 
+* `:Balance`
+
+  Show the pending and cleared balance of a given account below the status
+  line. For example:
+
+	:Balance checking:savings
+
+  The command offers payee and account autocompletion (see `:Ledger`). The
+  account argument is optional: if no argument is given, the first account
+  name found in the current line is used.
+
+  Two highlight groups can be used to customize the colors of the line:
+
+  * `LedgerCleared`
+
+    This is used to color the cleared balance.
+
+  * `LedgerPending`
+
+    This is used to color the pending balance.
+
 * `:Register`
 
   Opens an arbitrary register report in the quickfix window. For example:
@@ -231,6 +252,11 @@ behaviour of the ledger filetype.
 
   Filenames in the quickfix window are hidden by default. Set this to 1 is
   you want filenames to be visible.
+
+* Text of the output of the |:Balance| command:
+
+	let g:ledger_cleared_string = 'Cleared: '
+	let g:ledger_pending_string = 'Cleared or pending: '
 
 * For debugging purposes:
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -189,8 +189,9 @@ REPORTS                                                      *ledger-reports*
   may use |ledger#transaction_state_set()| to update a transaction's state.
   Every time you save your file, the balance and the difference from the
   target amount are updated at the bottom of the screen. The goal, of course,
-  is to get such difference to zero. To finish reconciling an account, simply
-  close the quickfix window.
+  is to get such difference to zero. You may press `<C-l>` to refresh the
+  Reconcile buffer. To finish reconciling an account, simply close the
+  quickfix window.
 
   There is a highlight group to customize the color of the difference from
   target:

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -293,10 +293,6 @@ behaviour of the ledger filetype.
 	let g:ledger_pending_string = 'Cleared or pending: '
 	let g:ledger_target_string = 'Difference from target: '
 
-* For debugging purposes:
-
-	let g:ledger_debug = 0
-
 ==============================================================================
 COMPLETION                                                 *ledger-completion*
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -107,8 +107,8 @@ REPORTS                                                      *ledger-reports*
   payee autocompletion (by pressing <Tab>): every name starting with `@` is
   autocompleted as a payee; any other name is autocompleted as an account.
 
-  In a report buffer, you may press <Tab> to switch back to the Ledger
-  buffer and `q` to dismiss the buffer report.
+  In a report buffer or in the quickfix window, you may press <Tab> to switch
+  back to your source file, and you may press `q` to dismiss the current window.
 
   There are three highlight groups that are used to color the report:
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -240,6 +240,12 @@ behaviour of the ledger filetype.
 
         let g:ledger_commodity_sep = ''
 
+* The file to be used to generate reports:
+
+        let g:ledger_main = '%'
+
+  The default is to use the current file.
+
 * Position of a report buffer:
 
         let g:ledger_winpos = 'B'

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -9,6 +9,7 @@ Contents:
         Source................|ledger-source|
         Usage..................|ledger-usage|
         Tips....................|ledger-tips|
+        Reports..............|ledger-reports|
         Settings............|ledger-settings|
         Completion........|ledger-completion|
         License..............|ledger-license|
@@ -93,6 +94,37 @@ Tips and useful commands
   This is a front end to `ledger entry`.
 
 ==============================================================================
+REPORTS                                                      *ledger-reports*
+
+* `:Ledger`
+
+  Executes an arbitrary Ledger command and sends the output to a new buffer.
+  For example:
+
+        :Ledger bal ^assets ^liab
+
+  Errors are displayed in a quickfix window. The command offers account and
+  payee autocompletion (by pressing <Tab>): every name starting with `@` is
+  autocompleted as a payee; any other name is autocompleted as an account.
+
+  In a report buffer, you may press <Tab> to switch back to the Ledger
+  buffer and `q` to dismiss the buffer report.
+
+  There are three highlight groups that are used to color the report:
+
+  * `LedgerNumber`
+
+    This is used to color nonnegative numbers.
+
+  * `LedgerNegativeNumber`
+
+    This is used to color negative numbers.
+
+  * `LedgerImproperPerc`
+
+    This is used to color improper percentages.
+
+==============================================================================
 SETTINGS                                                     *ledger-settings*
 
 Configuration
@@ -149,6 +181,44 @@ behaviour of the ledger filetype.
 * String to be put between the commodity and the amount:
 
         let g:ledger_commodity_sep = ''
+
+* Position of a report buffer:
+
+        let g:ledger_winpos = 'B'
+
+  Use `b` for bottom, `t` for top, `l` for left, `r` for right. Use uppercase letters
+  if you want the window to always occupy the full width or height.
+
+* Flag that tells whether a location list or a quickfix list should be used:
+
+	let g:ledger_use_location_list = 0
+
+  The default is to use the quickfix window. Set to 1 to use a location list.
+
+* Position of the quickfix/location list:
+
+	let g:ledger_qf_vertical = 0
+
+  Set to 1 to open the quickfix window in a vertical split.
+
+* Size of the quickfix window:
+
+	let g:ledger_qf_size = 10
+
+  This is the number of lines of a horizontal quickfix window, or the number
+  of columns of a vertical quickfix window.
+
+* Flag to show or hide filenames in the quickfix window:
+
+	let g:ledger_qf_hide_file = 1
+
+  Filenames in the quickfix window are hidden by default. Set this to 1 is
+  you want filenames to be visible.
+
+* For debugging purposes:
+
+	let g:ledger_debug = 0
+
 ==============================================================================
 COMPLETION                                                 *ledger-completion*
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -32,6 +32,17 @@ Tips and useful commands
 
 * Try account-completion (as explained below)
 
+* You may use `:make` for syntax checking. It may be convenient to define a
+  mapping for the following command:
+
+	:silent make | redraw! | cwindow
+
+  It is recommended to set the value of `g:ledger_bin` (see below) as follows:
+
+        let g:ledger_bin = 'ledger --pedantic --explicit --check-payees'
+
+  to catch most potential problems in your source file.
+
 * `:call ledger#transaction_date_set('.'), "auxiliary")`
 
   will set today's date as the auxiliary date of the current transaction. You

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -124,6 +124,16 @@ REPORTS                                                      *ledger-reports*
 
     This is used to color improper percentages.
 
+* `:Register`
+
+  Opens an arbitrary register report in the quickfix window. For example:
+
+	:Register groceries -p 'this month'
+
+  The command offers account and payee autocompletion (see |:Ledger|). You
+  may use the standard quickfix commands to jump from an entry in the register
+  report to the corresponding location in the source file.
+
 ==============================================================================
 SETTINGS                                                     *ledger-settings*
 
@@ -188,6 +198,13 @@ behaviour of the ledger filetype.
 
   Use `b` for bottom, `t` for top, `l` for left, `r` for right. Use uppercase letters
   if you want the window to always occupy the full width or height.
+
+* Format of quickfix register reports (see |:Register|):
+
+	let g:ledger_qf_register_format = \
+        '%(date) %-50(payee) %-30(account) %15(amount) %15(total)\n'
+
+  The format is specified using the standard Ledger syntax for --format.
 
 * Flag that tells whether a location list or a quickfix list should be used:
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -37,9 +37,10 @@ Tips and useful commands
 
 	:silent make | redraw! | cwindow
 
-  It is recommended to set the value of `g:ledger_bin` (see below) as follows:
+  It is recommended to set the value of `g:ledger_extra_options` (see below)
+  as follows:
 
-        let g:ledger_bin = 'ledger --pedantic --explicit --check-payees'
+        let g:ledger_extra_options = '--pedantic --explicit --check-payees'
 
   to catch most potential problems in your source file.
 
@@ -208,6 +209,14 @@ Configuration
 
 Include the following let-statements somewhere in your `.vimrc` to modify the
 behaviour of the ledger filetype.
+
+* Path to the `ledger` executable:
+
+	let g:ledger_bin = 'ledger'
+
+* Additional default options for the `ledger` executable:
+
+	let g:ledger_extra_options = ''
 
 * Number of columns that will be used to display the foldtext. Set this when
   you think that the amount is too far off to the right.

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -169,6 +169,9 @@ REPORTS                                                      *ledger-reports*
   Terminal.app in OS X 10.11 or later), you may also double-click on a line
   number in the quickfix window to jump to the corresponding posting.
 
+  It is strongly recommended that you add mappings for common quickfix
+  commands like `:cprev` and `:cnext`, or that you use T. Pope's Unimpaired
+  plugin.
 
 * :`Reconcile`
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -164,7 +164,11 @@ REPORTS                                                      *ledger-reports*
 
   The command offers account and payee autocompletion (see |:Ledger|). You
   may use the standard quickfix commands to jump from an entry in the register
-  report to the corresponding location in the source file.
+  report to the corresponding location in the source file. If you use GUI Vim
+  or if your terminal has support for the mouse (e.g., iTerm2, or even
+  Terminal.app in OS X 10.11 or later), you may also double-click on a line
+  number in the quickfix window to jump to the corresponding posting.
+
 
 * :`Reconcile`
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -417,26 +417,26 @@ function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
         \ "v:val =~? '" . a:argLead . "' && v:val !~? '^Warning: '"), 'escape(v:val, " ")')
 endf "}}}
 
-function! s:reconcile(account) "{{{2
+function! s:reconcile(file, account) "{{{2
   " call inputsave()
   let l:amount = input('Target amount' . (empty(g:ledger_default_commodity) ? ': ' : ' (' . g:ledger_default_commodity . '): '))
   " call inputrestore()
-  call ledger#reconcile(a:account, str2float(l:amount))
+  call ledger#reconcile(a:file, a:account, str2float(l:amount))
 endf "}}}
 
 " Commands {{{1
 command! -buffer -nargs=? -complete=customlist,s:autocomplete_account_or_payee
-      \ Balance call ledger#show_balance(<q-args>)
+      \ Balance call ledger#show_balance(g:ledger_main, <q-args>)
 
 command! -buffer -nargs=+ -complete=customlist,s:autocomplete_account_or_payee
-      \ Ledger call ledger#report('-f ' . g:ledger_main . ' ' . <q-args>)
+      \ Ledger call ledger#report(g:ledger_main, <q-args>)
 
 command! -buffer -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
 
 command! -buffer -nargs=1 -complete=customlist,s:autocomplete_account_or_payee
-      \ Reconcile call <sid>reconcile(<q-args>)
+      \ Reconcile call <sid>reconcile(g:ledger_main, <q-args>)
 
 command! -buffer -complete=customlist,s:autocomplete_account_or_payee -nargs=*
-      \ Register call ledger#register('-f ' . g:ledger_main . ' ' . <q-args>)
+      \ Register call ledger#register(g:ledger_main, <q-args>)
 " }}}
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -103,6 +103,40 @@ if !exists('g:ledger_include_original')
   let g:ledger_include_original = 0
 endif
 
+" Settings for Ledger reports {{{
+if !exists('g:ledger_winpos')
+  let g:ledger_winpos = 'B'  " Window position (see s:winpos_map)
+endif
+
+if !exists('g:ledger_use_location_list')
+  let g:ledger_use_location_list = 0  " Use quickfix list by default
+endif
+" }}}
+
+" Settings for the quickfix window {{{
+if !exists('g:ledger_qf_size')
+  let g:ledger_qf_size = 10  " Size of the quickfix window
+endif
+
+if !exists('g:ledger_qf_vertical')
+  let g:ledger_qf_vertical = 0
+endif
+
+if !exists('g:ledger_qf_hide_file')
+  let g:ledger_qf_hide_file = 1
+endif
+" }}}
+
+" Highlight groups for Ledger reports {{{
+hi! link LedgerNumber Number
+hi! link LedgerNegativeNumber Special
+hi! link LedgerImproperPerc Special
+" }}}
+
+if !exists('g:ledger_debug')
+  let g:ledger_debug = 0
+endif
+
 let s:rx_amount = '\('.
                 \   '\%([0-9]\+\)'.
                 \   '\%([,.][0-9]\+\)*'.
@@ -347,7 +381,20 @@ function! s:count_expression(text, expression) "{{{2
   return len(split(a:text, a:expression, 1))-1
 endf "}}}
 
+function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
+  return (a:argLead =~ '^@') ?
+        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' payees'),
+        \ "v:val =~? '" . strpart(a:argLead, 1) . "'"), '"@" . v:val')
+        \ :
+        \ filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' accounts'),
+        \ "v:val =~? '" . a:argLead . "'")
+endf "}}}
+
 " Commands {{{1
+if !exists(":Ledger")
+  command -complete=customlist,s:autocomplete_account_or_payee -nargs=+ Ledger call ledger#report(<q-args>)
+endif
+
 if !exists(":LedgerAlign")
   command -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
 endif

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -156,10 +156,6 @@ hi! link LedgerTarget Statement
 hi! link LedgerImproperPerc Special
 " }}}
 
-if !exists('g:ledger_debug')
-  let g:ledger_debug = 0
-endif
-
 let s:rx_amount = '\('.
                 \   '\%([0-9]\+\)'.
                 \   '\%([,.][0-9]\+\)*'.

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -104,6 +104,10 @@ if !exists('g:ledger_include_original')
 endif
 
 " Settings for Ledger reports {{{
+if !exists('g:ledger_main')
+  let g:ledger_main = '%'
+endif
+
 if !exists('g:ledger_winpos')
   let g:ledger_winpos = 'B'  " Window position (see s:winpos_map)
 endif

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -119,11 +119,19 @@ endif
 if !exists('g:ledger_pending_string')
   let g:ledger_pending_string = 'Cleared or pending: '
 endif
+
+if !exists('g:ledger_target_string')
+  let g:ledger_target_string = 'Difference from target: '
+endif
 " }}}
 
 " Settings for the quickfix window {{{
 if !exists('g:ledger_qf_register_format')
   let g:ledger_qf_register_format = '%(date) %-50(payee) %-30(account) %15(amount) %15(total)\n'
+endif
+
+if !exists('g:ledger_qf_reconcile_format')
+  let g:ledger_qf_reconcile_format = '%(date) %-4(code) %-50(payee) %-30(account) %15(amount)\n'
 endif
 
 if !exists('g:ledger_qf_size')
@@ -144,6 +152,7 @@ hi! link LedgerNumber Number
 hi! link LedgerNegativeNumber Special
 hi! link LedgerCleared Constant
 hi! link LedgerPending Todo
+hi! link LedgerTarget Statement
 hi! link LedgerImproperPerc Special
 " }}}
 
@@ -404,6 +413,13 @@ function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
         \ "v:val =~? '" . a:argLead . "'")
 endf "}}}
 
+function! s:reconcile(account) "{{{2
+  " call inputsave()
+  let l:amount = input('Target amount' . (empty(g:ledger_default_commodity) ? ': ' : ' (' . g:ledger_default_commodity . '): '))
+  " call inputrestore()
+  call ledger#reconcile(a:account, l:amount)
+endf "}}}
+
 " Commands {{{1
 if !exists(":Balance")
   command -nargs=? -complete=customlist,s:autocomplete_account_or_payee Balance call ledger#show_balance(<q-args>)
@@ -415,6 +431,10 @@ endif
 
 if !exists(":LedgerAlign")
   command -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
+endif
+
+if !exists(":Reconcile")
+  command -nargs=1 -complete=customlist,s:autocomplete_account_or_payee Reconcile call <sid>reconcile(<q-args>)
 endif
 
 if !exists(":Register")

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -114,6 +114,10 @@ endif
 " }}}
 
 " Settings for the quickfix window {{{
+if !exists('g:ledger_qf_register_format')
+  let g:ledger_qf_register_format = '%(date) %-50(payee) %-30(account) %15(amount) %15(total)\n'
+endif
+
 if !exists('g:ledger_qf_size')
   let g:ledger_qf_size = 10  " Size of the quickfix window
 endif
@@ -397,6 +401,10 @@ endif
 
 if !exists(":LedgerAlign")
   command -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
+endif
+
+if !exists(":Register")
+  command -complete=customlist,s:autocomplete_account_or_payee -nargs=* Register call ledger#register(<q-args>)
 endif
 " }}}
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -417,7 +417,7 @@ function! s:reconcile(account) "{{{2
   " call inputsave()
   let l:amount = input('Target amount' . (empty(g:ledger_default_commodity) ? ': ' : ' (' . g:ledger_default_commodity . '): '))
   " call inputrestore()
-  call ledger#reconcile(a:account, l:amount)
+  call ledger#reconcile(a:account, str2float(l:amount))
 endf "}}}
 
 " Commands {{{1

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -111,6 +111,14 @@ endif
 if !exists('g:ledger_use_location_list')
   let g:ledger_use_location_list = 0  " Use quickfix list by default
 endif
+
+if !exists('g:ledger_cleared_string')
+  let g:ledger_cleared_string = 'Cleared: '
+endif
+
+if !exists('g:ledger_pending_string')
+  let g:ledger_pending_string = 'Cleared or pending: '
+endif
 " }}}
 
 " Settings for the quickfix window {{{
@@ -134,6 +142,8 @@ endif
 " Highlight groups for Ledger reports {{{
 hi! link LedgerNumber Number
 hi! link LedgerNegativeNumber Special
+hi! link LedgerCleared Constant
+hi! link LedgerPending Todo
 hi! link LedgerImproperPerc Special
 " }}}
 
@@ -395,6 +405,10 @@ function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
 endf "}}}
 
 " Commands {{{1
+if !exists(":Balance")
+  command -nargs=? -complete=customlist,s:autocomplete_account_or_payee Balance call ledger#show_balance(<q-args>)
+endif
+
 if !exists(":Ledger")
   command -complete=customlist,s:autocomplete_account_or_payee -nargs=+ Ledger call ledger#report(<q-args>)
 endif

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -411,10 +411,10 @@ endf "}}}
 function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
   return (a:argLead =~ '^@') ?
         \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' payees'),
-        \ "v:val =~? '" . strpart(a:argLead, 1) . "'"), '"@" . escape(v:val, " ")')
+        \ "v:val =~? '" . strpart(a:argLead, 1) . "' && v:val !~? '^Warning: '"), '"@" . escape(v:val, " ")')
         \ :
         \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' accounts'),
-        \ "v:val =~? '" . a:argLead . "'"), 'escape(v:val, " ")')
+        \ "v:val =~? '" . a:argLead . "' && v:val !~? '^Warning: '"), 'escape(v:val, " ")')
 endf "}}}
 
 function! s:reconcile(account) "{{{2

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -406,10 +406,10 @@ endf "}}}
 
 function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
   return (a:argLead =~ '^@') ?
-        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' payees'),
+        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' payees'),
         \ "v:val =~? '" . strpart(a:argLead, 1) . "'"), '"@" . escape(v:val, " ")')
         \ :
-        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' accounts'),
+        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' accounts'),
         \ "v:val =~? '" . a:argLead . "'"), 'escape(v:val, " ")')
 endf "}}}
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -421,24 +421,18 @@ function! s:reconcile(account) "{{{2
 endf "}}}
 
 " Commands {{{1
-if !exists(":Balance")
-  command -nargs=? -complete=customlist,s:autocomplete_account_or_payee Balance call ledger#show_balance(<q-args>)
-endif
+command! -buffer -nargs=? -complete=customlist,s:autocomplete_account_or_payee
+      \ Balance call ledger#show_balance(<q-args>)
 
-if !exists(":Ledger")
-  command -complete=customlist,s:autocomplete_account_or_payee -nargs=+ Ledger call ledger#report(<q-args>)
-endif
+command! -buffer -nargs=+ -complete=customlist,s:autocomplete_account_or_payee
+      \ Ledger call ledger#report('-f ' . g:ledger_main . ' ' . <q-args>)
 
-if !exists(":LedgerAlign")
-  command -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
-endif
+command! -buffer -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
 
-if !exists(":Reconcile")
-  command -nargs=1 -complete=customlist,s:autocomplete_account_or_payee Reconcile call <sid>reconcile(<q-args>)
-endif
+command! -buffer -nargs=1 -complete=customlist,s:autocomplete_account_or_payee
+      \ Reconcile call <sid>reconcile(<q-args>)
 
-if !exists(":Register")
-  command -complete=customlist,s:autocomplete_account_or_payee -nargs=* Register call ledger#register(<q-args>)
-endif
+command! -buffer -complete=customlist,s:autocomplete_account_or_payee -nargs=*
+      \ Register call ledger#register('-f ' . g:ledger_main . ' ' . <q-args>)
 " }}}
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -407,10 +407,10 @@ endf "}}}
 function! s:autocomplete_account_or_payee(argLead, cmdLine, cursorPos) "{{{2
   return (a:argLead =~ '^@') ?
         \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' payees'),
-        \ "v:val =~? '" . strpart(a:argLead, 1) . "'"), '"@" . v:val')
+        \ "v:val =~? '" . strpart(a:argLead, 1) . "'"), '"@" . escape(v:val, " ")')
         \ :
-        \ filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' accounts'),
-        \ "v:val =~? '" . a:argLead . "'")
+        \ map(filter(systemlist(g:ledger_bin . ' -f ' . shellescape(expand('%')) . ' accounts'),
+        \ "v:val =~? '" . a:argLead . "'"), 'escape(v:val, " ")')
 endf "}}}
 
 function! s:reconcile(account) "{{{2

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -21,7 +21,7 @@ setl commentstring=;%s
 setl omnifunc=LedgerComplete
 
 " set location of ledger binary for checking and auto-formatting
-if ! exists("g:ledger_bin") || empty(g:ledger_bin) || ! executable(split(g:ledger_bin, '\s')[0])
+if ! exists("g:ledger_bin") || empty(g:ledger_bin) || ! executable(g:ledger_bin)
   if executable('ledger')
     let g:ledger_bin = 'ledger'
   else
@@ -35,6 +35,10 @@ endif
 
 if exists("g:ledger_bin")
   exe 'setl formatprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ -\ print'
+endif
+
+if !exists('g:ledger_extra_options')
+  let g:ledger_extra_options = ''
 endif
 
 " You can set a maximal number of columns the fold text (excluding amount)


### PR DESCRIPTION
This set of commits adds the following functionality:

- generate any kind of report inside Vim (sent to a new buffer);
- generate a register report in the quickfix window, so that it is synchronized with the source code;
- show an account's pending/cleared balance at the bottom of the screen (the account may be given explicitly or taken from the current line);
- reconcile an account (similar to the Ledger plugin for Emacs) using the quickfix window..

This is the last of the pull requests I wanted to submit. I hope that they will be accepted so I can prune my vim configuration :)
