### PR TITLE
Update 'include' pattern.

### DIFF
--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -15,7 +15,7 @@ let b:undo_ftplugin = "setlocal ".
 
 setl foldtext=LedgerFoldText()
 setl foldmethod=syntax
-setl include=^!include
+setl include=^!\\?include
 setl comments=b:;
 setl commentstring=;%s
 setl omnifunc=LedgerComplete


### PR DESCRIPTION
Use of '!' prepending Ledger command directives has been deprecated (see
Ledger's manual, §4.7.2).

This commit makes '!' optional in the 'include' pattern.

This fixes a bug by which `i_CTRL-X_CTRL-I` was not using included files for
autocompletion, because they were included with `include` rather than
`!include`.