### PR TITLE
Refactor Ledger execution into a separate function.

### DIFF
--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -108,6 +108,14 @@ Tips and useful commands
 ==============================================================================
 REPORTS                                                      *ledger-reports*
 
+* `:call ledger#exec(file, args)`
+
+  Executes an arbitrary Ledger command and returns the output as a List (one
+  element for each line of output). The first argument is the path to a Ledger
+  file. The second argument is a string of Ledger options (options specified via
+  `g:ledger_extra_options` are included by default). Errors are sent to
+  a quickfix window.
+
 * `:Ledger`
 
   Executes an arbitrary Ledger command and sends the output to a new buffer.


### PR DESCRIPTION
This pull request does not change any functionality, but it moves the code to execute a Ledger command into a separate, user-accessible, function. The reason is that it is useful to be able to capture the output of a Ledger command (e.g., to pipe it to Gnuplot or R for further processing).