### PR TITLE
Split ledger#report() function.

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -509,21 +509,34 @@ endfunc
 " Parameters:
 " file  The file to be processed.
 " args  A string of Ledger command-line arguments.
+"
+" Returns:
+" Ledger's output as a String.
 function! ledger#report(file, args)
   let l:output = systemlist(s:ledger_cmd(a:file, a:args))
   if v:shell_error  " If there are errors, show them in a quickfix/location list.
     call s:quickfix_populate(l:output)
     call s:quickfix_toggle('Errors', 'Unable to parse errors')
-    return
   endif
-  if empty(l:output)
+  return l:output
+endf
+
+" Open the output of a Ledger's command in a new buffer.
+"
+" Parameters:
+" report  A String containing the output of a Ledger's command.
+"
+" Returns:
+" 1 if a new buffer is created; 0 otherwise.
+function! ledger#output(report)
+  if empty(a:report)
     call s:warning_message('No results')
-    return
+    return 0
   endif
   " Open a new buffer to show Ledger's output.
   execute get(s:winpos_map, g:ledger_winpos, "bo new")
-  setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap
-  call append(0, l:output)
+  setlocal buftype=nofile bufhidden=wipe modifiable nobuflisted noswapfile nowrap
+  call append(0, a:report)
   setlocal nomodifiable
   " Set local mappings to quit window or lose focus.
   nnoremap <silent> <buffer> <tab> <c-w><c-w>
@@ -532,6 +545,7 @@ function! ledger#report(file, args)
   syntax match LedgerNumber /-\@1<!\d\+\([,.]\d\+\)\+/
   syntax match LedgerNegativeNumber /-\d\+\([,.]\d\+\)\+/
   syntax match LedgerImproperPerc /\d\d\d\+%/
+  return 1
 endf
 
 " Show an arbitrary register report in a quickfix list.

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -429,7 +429,7 @@ command! -buffer -nargs=? -complete=customlist,s:autocomplete_account_or_payee
       \ Balance call ledger#show_balance(g:ledger_main, <q-args>)
 
 command! -buffer -nargs=+ -complete=customlist,s:autocomplete_account_or_payee
-      \ Ledger call ledger#report(g:ledger_main, <q-args>)
+      \ Ledger call ledger#output(ledger#report(g:ledger_main, <q-args>))
 
 command! -buffer -range LedgerAlign <line1>,<line2>call ledger#align_commodity()
 


### PR DESCRIPTION
Currently, the function is responsible for two independent tasks:
running a report and creating a new buffer to display ledger’s output.

In some situations, it may be convenient to be able to run a report
without immediately displaying the output (e.g., because the user wants
to perform some post-processing or the user wants to send the output
somewhere else). Also, it is better to have functions that perform a
single, simple, task than to have monolithic functions that perform
multiple tasks. 

This commit addresses the above by splitting ledger#report() into two
functions:

- ledger#report(): now this just runs a ledger’s command and returns the
  output as a String.

- ledger#output(): this new function takes a String containing a report
  and creates a new buffer to display it.

Both functions have suitable return values that the user may use to
check a function’s result (note that, before this commit,
ledger#report() does not return anything).

This change is backward-compatible and should cause no regressions. In
particular, the behaviour of the :Ledger command remains unchanged.