### PR TITLE
Add BufRead event to filetype detection

### DIFF
--- a/ftdetect/ledger.vim
+++ b/ftdetect/ledger.vim
@@ -1,1 +1,1 @@
-autocmd BufEnter *.ldg,*.ledger setlocal filetype=ledger | compiler ledger
+autocmd BufEnter,BufRead *.ldg,*.ledger setlocal filetype=ledger | compiler ledger


### PR DESCRIPTION
When using vim-ledger in combination with vim-gnupg and an encrypted journal, the ledger filetype is not detected after vim-gnupg's automatic decryption.

This pull request adds the "BufRead" event to vim-ledger's filetype autocmd so that the ledger filetype will get set appropriately.