### PR TITLE
Allow completion from declared accounts

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -267,6 +267,50 @@ endf "}}}
 
 " == helper functions ==
 
+" get a list of declared accounts in the buffer
+function! ledger#declared_accounts(...)
+  if a:0 == 2
+    let lnum = a:1
+    let lend = a:2
+  elseif a:0 == 0
+    let lnum = 1
+    let lend = line('$')
+  else
+    throw "wrong number of arguments for ledger#declared_accounts()"
+    return []
+  endif
+
+  " save view / position
+  let view = winsaveview()
+  let fe = &foldenable
+  set nofoldenable
+
+  let accounts = []
+  call cursor(lnum, 0)
+  while 1
+    let lnum = search('^account\s', 'cW', lend)
+    if !lnum || lnum > lend
+      break
+    endif
+
+    " remove comments at the end and "account" at the front
+    let line = split(getline(lnum), '\s\+;')[0]
+    let line = matchlist(line, 'account\s\+\(.\+\)')[1]
+
+    if len(line) > 1
+      call add(accounts, line)
+    endif
+
+    call cursor(lnum+1,0)
+  endw
+
+  " restore view / position
+  let &foldenable = fe
+  call winrestview(view)
+
+  return accounts
+endf
+
 function! s:get_transaction_extents(lnum)
   if ! (indent(a:lnum) || getline(a:lnum) =~ '^[~=[:digit:]]')
     " only do something if lnum is in a transaction

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -330,7 +330,7 @@ unlet s:old s:new s:fun
 function! s:collect_completion_data() "{{{1
   let transactions = ledger#transactions()
   let cache = {'descriptions': [], 'tags': {}, 'accounts': {}}
-  let accounts = []
+  let accounts = ledger#declared_accounts()
   for xact in transactions
     " collect descriptions
     if has_key(xact, 'description') && index(cache.descriptions, xact['description']) < 0


### PR DESCRIPTION
When using ledger with the `--strict` option, you need to declare all your used accounts. These declarations can additionally be used to complete account names.