### PR TITLE
ledger_cmd: include settings from g:ledger_date_format

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -494,7 +494,12 @@ endf
 
 " Build a ledger command to process the given file.
 function! s:ledger_cmd(file, args)
-  return join([g:ledger_bin, g:ledger_extra_options, '-f', shellescape(expand(a:file)), a:args])
+  let l:options = g:ledger_extra_options
+  if len(g:ledger_date_format) > 0
+    let l:options = join([l:options, "--date-format", g:ledger_date_format,
+      \ "--input-date-format", g:ledger_date_format])
+  endif
+  return join([g:ledger_bin, l:options, '-f', shellescape(expand(a:file)), a:args])
 endf
 " }}}
 

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -545,7 +545,7 @@ endf
 " Build a ledger command to process the given file.
 function! s:ledger_cmd(file, args) abort
   let l:options = g:ledger_extra_options
-  if len(g:ledger_date_format) > 0
+  if len(g:ledger_date_format) > 0 && !g:ledger_is_hledger
     let l:options = join([l:options, '--date-format', g:ledger_date_format,
       \ '--input-date-format', g:ledger_date_format])
   endif


### PR DESCRIPTION
vim-ledger understands the option `g:ledger_date_format` which controls the formatting of the journal file. But when ledger tries to read such files, e.g. when calling `ledger#entry()`, it gets confused about the date format. Solve this by adding `g:ledger_date_format` as input and output date formats to the ledger command line.