### PR TITLE
Fix report highlighting

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -570,8 +570,8 @@ function! ledger#output(report)
   nnoremap <silent> <buffer> <tab> <c-w><c-p>
   nnoremap <silent> <buffer> q <c-w><c-p>@=winnr("#")<cr><c-w>c
   " Add some coloring to the report
-  syntax match LedgerNumber /-\@1<!\d\+\([,.]\d\+\)\+/
-  syntax match LedgerNegativeNumber /-\d\+\([,.]\d\+\)\+/
+  syntax match LedgerNumber /-\@1<!\d\+\([,.]\d\+\)*/
+  syntax match LedgerNegativeNumber /-\d\+\([,.]\d\+\)*/
   syntax match LedgerImproperPerc /\d\d\d\+%/
   return 1
 endf

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -160,12 +160,12 @@ endif
 " }}}
 
 " Highlight groups for Ledger reports {{{
-hi! link LedgerNumber Number
-hi! link LedgerNegativeNumber Special
-hi! link LedgerCleared Constant
-hi! link LedgerPending Todo
-hi! link LedgerTarget Statement
-hi! link LedgerImproperPerc Special
+hi link LedgerNumber Number
+hi link LedgerNegativeNumber Special
+hi link LedgerCleared Constant
+hi link LedgerPending Todo
+hi link LedgerTarget Statement
+hi link LedgerImproperPerc Special
 " }}}
 
 let s:rx_amount = '\('.


### PR DESCRIPTION
The first commit fixes #52, where colorschemes cannot override certain highlight groups. The second commit fixes a couple regexps that fail to match integer values which contain no decimal or comma.