### PR TITLE
Small improvements to the syntax highlighting:

### DIFF
--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -52,6 +52,8 @@ syn match ledgerDirective
   \ /^\%(alias\|assert\|bucket\|capture\|check\|define\|expr\|fixed\|include\|year\)\s/
 syn match ledgerOneCharDirective /^\%(P\|A\|Y\|N\|D\|C\)\s/
 
+syn region ledgerBlockComment start=/^comment/ end=/^end comment/
+syn region ledgerBlockTest start=/^test/ end=/^end test/
 syn match ledgerComment /^;.*$/
 " comments at eol must be preceded by at least 2 spaces / 1 tab
 syn region ledgerMetadata start=/\%(  \|\t\|^\s\+\);/ skip=/^\s\+;/ end=/^/
@@ -74,6 +76,8 @@ exe 'syn match ledgerApplyHead '.
   \ '/'.s:oe.'\%(^apply\s\+\)\@<=\S.*$/ contained'
 
 highlight default link ledgerComment Comment
+highlight default link ledgerBlockComment Comment
+highlight default link ledgerBlockTest Comment
 highlight default link ledgerTransactionDate Constant
 highlight default link ledgerTransactionExpression Statement
 highlight default link ledgerMetadata Tag

--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -48,6 +48,10 @@ syn match ledgerPreDeclarationType /^\(account\|payee\|commodity\|tag\)/ contain
 syn match ledgerPreDeclarationName /^\S\+\s\+\zs.*/ contained
 syn match ledgerPreDeclarationDirective /^\s\+\zs\S\+/ contained
 
+syn match ledgerDirective
+  \ /^\%(alias\|assert\|bucket\|capture\|check\|define\|expr\|fixed\|include\|year\)\s/
+syn match ledgerOneCharDirective /^\%(P\|A\|Y\|N\|D\|C\)\s/
+
 syn match ledgerComment /^;.*$/
 " comments at eol must be preceded by at least 2 spaces / 1 tab
 syn region ledgerMetadata start=/\%(  \|\t\|^\s\+\);/ skip=/^\s\+;/ end=/^/
@@ -84,6 +88,8 @@ highlight default link ledgerAmount Number
 highlight default link ledgerPreDeclarationType Type
 highlight default link ledgerPreDeclarationName Identifier
 highlight default link ledgerPreDeclarationDirective Type
+highlight default link ledgerDirective Type
+highlight default link ledgerOneCharDirective Type
  
 " syncinc is easy: search for the first transaction.
 syn sync clear

--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -54,7 +54,7 @@ syn match ledgerOneCharDirective /^\%(P\|A\|Y\|N\|D\|C\)\s/
 
 syn region ledgerBlockComment start=/^comment/ end=/^end comment/
 syn region ledgerBlockTest start=/^test/ end=/^end test/
-syn match ledgerComment /^;.*$/
+syn match ledgerComment /^[;|*#].*$/
 " comments at eol must be preceded by at least 2 spaces / 1 tab
 syn region ledgerMetadata start=/\%(  \|\t\|^\s\+\);/ skip=/^\s\+;/ end=/^/
     \ keepend contained contains=ledgerTags,ledgerValueTag,ledgerTypedTag


### PR DESCRIPTION
* highlight all known directives known to the documentation
* support all allowed single-line comment characters
* support multiline comment blocks

For the block comments, I've read [section 14.2.1](http://ledger-cli.org/3.0/doc/ledger3.html#Comments-and-meta_002ddata) of the documentation very carefully three times now and something like this should be counted as a comment:

```
comment
This is a comment.
It can span multiple lines.
end
```

However, in my case with ledger 3.1.2-20160801, if I actually put this snippet into my journal, this leads to all statements after that comment being ignored by ledger. I'm not sure if this is actually a bug in ledger, so if someone could shed light at this, I'd be happy to fix the highlighting if I understood the docs wrong.