### PR TITLE
Auto reload implementation.

### DIFF
--- a/ftdetect/ledger.vim
+++ b/ftdetect/ledger.vim
@@ -1,1 +1,2 @@
-autocmd BufEnter,BufRead *.ldg,*.ledger setlocal filetype=ledger | compiler ledger
+autocmd BufEnter,BufRead *.ledger setlocal filetype=ledger | compiler ledger
+autocmd BufEnter,BufRead *.ldg setlocal filetype=ledger | compiler ledger

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -443,3 +443,7 @@ command! -buffer -complete=customlist,s:autocomplete_account_or_payee -nargs=*
       \ Register call ledger#register(g:ledger_main, <q-args>)
 " }}}
 
+" Auto reloa {{{1
+autocmd BufWritePost *.ledger call ledger#UpdateFile()
+autocmd BufWritePost *.ldg call ledger#UpdateFile()
+" }}}


### PR DESCRIPTION
I've made a auto reload implementation that has being really useful for me.

Whenever a report is executed (``:Ledger bal``) it is marked as the last report.
When saving a .ledger/.ldg file, it is re executed, without opening a quickfix window.

I am not using vim for a long time, nor ledger, but I think it can be a good feature to add to vim-ledger.