### PR TITLE
Fix autocompletion endless loop for last line in file

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -99,7 +99,7 @@ function! ledger#transactions(...)
 
   let transactions = []
   call cursor(lnum, 0)
-  while lnum && lnum <= end
+  while lnum && lnum < end
     let trans = s:transaction.from_lnum(lnum)
     if ! empty(trans)
       call add(transactions, trans)


### PR DESCRIPTION
Error can be reproduced on this file:

```
2019/07/01 Transaction
    Assets                                 $100.00
    Income

2019-07-02 T<C-x><C-o>
```

Line `2019-07-02 T` should be last line in a file (no blank line after it) and then you try to compete transaction name it's would run endless loop.