### PR TITLE
Fetch account list for completion from external command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -85,7 +85,7 @@ behaviour of the ledger filetype.
 Completion
 ----------
 
-Omni completion is currently implemented for account names only.
+Omni completion is implemented for transactions descriptions and posting account names.
 
 ### Accounts
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -254,6 +254,22 @@ behaviour of the ledger filetype.
 
 	let g:ledger_extra_options = ''
 
+* To use a custom external system command to generate a list of account names
+  for completion, set the following. If g:ledger_bin is set, this will default
+  to running that command with arguments to parse the current file using the
+  accounts subcommand (works with ledger or hledger), otherwise it will parse
+  the postings in the current file itself.
+
+	let g:ledger_accounts_cmd = 'your_command args'
+
+* To use a custom external system command to generate a list of descriptions
+  for completion, set the following. If g:ledger_bin is set, this will default
+  to running that command with arguments to parse the current file using the
+  descriptions subcommand (works with ledger or hledger), otherwise it will
+  parse the transactions in the current file itself.
+
+	let g:ledger_descriptions_cmd = 'your_command args'
+
 * Number of columns that will be used to display the foldtext. Set this when
   you think that the amount is too far off to the right.
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -64,16 +64,10 @@ if !exists('g:ledger_fillstring')
   let g:ledger_fillstring = ' '
 endif
 
-if !exists('g:ledger_accounts_generate')
-	let g:ledger_accounts_generate = 0
-endif
-
 if !exists("g:ledger_accounts_cmd")
-	if exists("g:ledger_bin")
-		let g:ledger_accounts_cmd = g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' accounts'
-	else
-		let g:ledger_accounts_generate = 0
-	endif
+  if exists("g:ledger_bin")
+    let g:ledger_accounts_cmd = g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' accounts'
+  endif
 endif
 
 if !exists('g:ledger_decimal_sep')
@@ -345,7 +339,7 @@ unlet s:old s:new s:fun
 function! s:collect_completion_data() "{{{1
   let transactions = ledger#transactions()
   let cache = {'descriptions': [], 'tags': {}, 'accounts': {}}
-  if g:ledger_accounts_generate && exists("g:ledger_accounts_cmd")
+  if exists("g:ledger_accounts_cmd")
     let accounts = systemlist(g:ledger_accounts_cmd)
   else
     let accounts = ledger#declared_accounts()
@@ -359,7 +353,7 @@ function! s:collect_completion_data() "{{{1
     let tagdicts = [t]
 
 		" collect account names
-    if !g:ledger_accounts_generate && !exists("g:ledger_accounts_cmd")
+    if !exists("g:ledger_accounts_cmd")
       for posting in postings
         if has_key(posting, 'tags')
           call add(tagdicts, posting.tags)

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -70,6 +70,12 @@ if !exists("g:ledger_accounts_cmd")
   endif
 endif
 
+if !exists("g:ledger_descriptions_cmd")
+  if exists("g:ledger_bin")
+    let g:ledger_descriptions_cmd = g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' descriptions'
+  endif
+endif
+
 if !exists('g:ledger_decimal_sep')
   let g:ledger_decimal_sep = '.'
 endif
@@ -344,10 +350,15 @@ function! s:collect_completion_data() "{{{1
   else
     let accounts = ledger#declared_accounts()
   endif
+  if exists("g:ledger_descriptions_cmd")
+    let cache.descriptions = systemlist(g:ledger_descriptions_cmd)
+  endif
   for xact in transactions
-    " collect descriptions
-    if has_key(xact, 'description') && index(cache.descriptions, xact['description']) < 0
-      call add(cache.descriptions, xact['description'])
+    if !exists("g:ledger_descriptions_cmd")
+      " collect descriptions
+      if has_key(xact, 'description') && index(cache.descriptions, xact['description']) < 0
+        call add(cache.descriptions, xact['description'])
+      endif
     endif
     let [t, postings] = xact.parse_body()
     let tagdicts = [t]

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -342,15 +342,9 @@ function! s:collect_completion_data() "{{{1
     let [t, postings] = xact.parse_body()
     let tagdicts = [t]
 
-    " collect account names
     for posting in postings
       if has_key(posting, 'tags')
         call add(tagdicts, posting.tags)
-      endif
-      " remove virtual-transaction-marks
-      let name = substitute(posting.account, '\%(^\s*[\[(]\?\|[\])]\?\s*$\)', '', 'g')
-      if index(accounts, name) < 0
-        call add(accounts, name)
       endif
     endfor
 
@@ -363,6 +357,11 @@ function! s:collect_completion_data() "{{{1
       let cache.tags[tag] = values
     endfor | endfor
   endfor
+
+  let cmd = g:ledger_bin . ' -f ' . shellescape(expand('%'))
+        \ . " --balance-format=\"%A\\n\" --flat bal"
+  let output = system(cmd)
+  let accounts = split(output, '\n')
 
   for account in accounts
     let last = cache.accounts

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -23,6 +23,10 @@ setl comments=b:;
 setl commentstring=;%s
 setl omnifunc=LedgerComplete
 
+if !exists('g:ledger_main')
+  let g:ledger_main = '%'
+endif
+
 " set location of ledger binary for checking and auto-formatting
 if ! exists("g:ledger_bin") || empty(g:ledger_bin) || ! executable(g:ledger_bin)
   if executable('ledger')
@@ -58,6 +62,18 @@ endif
 
 if !exists('g:ledger_fillstring')
   let g:ledger_fillstring = ' '
+endif
+
+if !exists('g:ledger_accounts_generate')
+	let g:ledger_accounts_generate = 0
+endif
+
+if !exists("g:ledger_accounts_cmd")
+	if exists("g:ledger_bin")
+		let g:ledger_accounts_cmd = g:ledger_bin . ' -f ' . shellescape(expand(g:ledger_main)) . ' accounts'
+	else
+		let g:ledger_accounts_generate = 0
+	endif
 endif
 
 if !exists('g:ledger_decimal_sep')
@@ -115,10 +131,6 @@ if !exists('g:ledger_include_original')
 endif
 
 " Settings for Ledger reports {{{
-if !exists('g:ledger_main')
-  let g:ledger_main = '%'
-endif
-
 if !exists('g:ledger_winpos')
   let g:ledger_winpos = 'B'  " Window position (see s:winpos_map)
 endif
@@ -343,7 +355,7 @@ function! s:collect_completion_data() "{{{1
     let tagdicts = [t]
 
 		" collect account names
-		if exists("g:ledger_accounts_cmd")
+		if g:ledger_accounts_generate && exists("g:ledger_accounts_cmd")
 			let accounts = split(system(g:ledger_accounts_cmd), '\n')
 		else
 			for posting in postings


### PR DESCRIPTION
This is an alternative way of fetching account names for completion based on @chadvoegele's initial hack in https://github.com/chadvoegele/vim-ledger/commit/d9eef4168812ec61035dc00d0578e60f97c5a653. Instead of parsing the postings of each transaction in the current file we call out to `ledger` (or in my case `hledger`) to get a list of possible accounts. This has the huge advantage (at least in my use case) of parsing includes and coming up with a complete account map, not just whatever might happen to be in the current file.

- [x] Optionally fetch account list from external command
- ~~[ ] Setup easier to use Boolean on/off flag that combines `g:ledger_bin` and the current file name if no custom command set~~ I did this, then backtracked on it because it make first time setup so much more complicated for no value. If an external ledger binary is available, using it seems to me _always_ better than parsing the file in vimscript.
- [x] Document usage