### PR TITLE
Cleanup vim and ledger version compatability

### DIFF
--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -23,6 +23,8 @@ endif
 let s:oe = '\%#=1'
 let s:lb1 = '\@1<='
 
+let s:line_comment_chars = b:is_hledger ? ';*#' : ';|*#%'
+
 let s:fb = get(g:, 'ledger_fold_blanks', 0)
 let s:skip = s:fb > 0 ? '\|^\n' : ''
 if s:fb == 1
@@ -69,7 +71,7 @@ syn match ledgerOneCharDirective /^\%(P\|A\|Y\|N\|D\|C\)\s/
 
 syn region ledgerBlockComment start=/^comment/ end=/^end comment/
 syn region ledgerBlockTest start=/^test/ end=/^end test/
-syn match ledgerComment /^[;|*#].*$/
+exe 'syn match ledgerComment /^['.s:line_comment_chars.'].*$/'
 " comments at eol must be preceded by at least 2 spaces / 1 tab
 syn region ledgerMetadata start=/\%(\s\s\|\t\|^\s\+\);/ skip=/^\s\+;/ end=/^/
     \ keepend contained contains=ledgerTags,ledgerValueTag,ledgerTypedTag

--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -7,15 +7,13 @@
 
 scriptencoding utf-8
 
-if v:version < 600
-  syntax clear
-elseif exists('b:current_sytax')
+if exists('b:current_sytax')
   finish
 endif
 
 " Force old regex engine (:help two-engines)
-let s:oe = v:version < 704 ? '' : '\%#=1'
-let s:lb1 = v:version < 704 ? '\@<=' : '\@1<='
+let s:oe = '\%#=1'
+let s:lb1 = '\@1<='
 
 let s:fb = get(g:, 'ledger_fold_blanks', 0)
 let s:skip = s:fb > 0 ? '\|^\n' : ''

--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -11,6 +11,14 @@ if exists('b:current_syntax')
   finish
 endif
 
+if !exists ('b:is_hledger')
+  if exists('g:ledger_is_hledger')
+    let b:is_hledger = 1
+  else
+    let b:is_hledger = 0
+  endif
+endif
+
 " Force old regex engine (:help two-engines)
 let s:oe = '\%#=1'
 let s:lb1 = '\@1<='
@@ -107,4 +115,4 @@ highlight default link ledgerOneCharDirective Type
 syn sync clear
 syn sync match ledgerSync grouphere ledgerTransaction "^[[:digit:]~=]"
  
-let b:current_syntax = 'ledger'
+let b:current_syntax = b:is_hledger ? 'hledger' : 'ledger'

--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -7,7 +7,7 @@
 
 scriptencoding utf-8
 
-if exists('b:current_sytax')
+if exists('b:current_syntax')
   finish
 endif
 


### PR DESCRIPTION
VIM 5 was replaced by version 6 in 2001. If you haven't updated your editor in 18 years you are gnarly and can jolly well patch this plugin to work on your editor yourself. It's not worth the mess to the rest of us. Notably [no distros](https://repology.org/project/vim/versions) ship  anything older than 7.0 at the dead worst and the vast majority are on 8.1.x; a handful have 7.4 era builds.

Also the check to not apply syntax if already loaded has clearly not been working at all, it has had a fatal typo mix matching variables since 2009.