### PR TITLE
Fix makeprg to work around ledger cli bug

### DIFF
--- a/compiler/ledger.vim
+++ b/compiler/ledger.vim
@@ -22,7 +22,7 @@ if !g:ledger_is_hledger
 	CompilerSet errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
 	" Skip all other lines:
 	CompilerSet errorformat+=%-G%.%#
-
-	" Check file syntax
 	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ %\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ %'
+else
+	exe 'CompilerSet makeprg=('.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ %\ print\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ >\ /dev/null)'
 endif

--- a/compiler/ledger.vim
+++ b/compiler/ledger.vim
@@ -5,27 +5,24 @@
 
 scriptencoding utf-8
 
-if exists('current_compiler')
+if exists('current_compiler') || !exists('g:ledger_bin')
   finish
 endif
-let current_compiler = 'ledger'
+
+let current_compiler = g:ledger_bin
 
 if exists(':CompilerSet') != 2
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-" default value will be set in ftplugin
-if ! exists('g:ledger_bin') || empty(g:ledger_bin) || ! executable(g:ledger_bin)
-  finish
+if !g:ledger_is_hledger
+	" Capture Ledger errors (%-C ignores all lines between "While parsing..." and "Error:..."):
+	CompilerSet errorformat=%EWhile\ parsing\ file\ \"%f\"\\,\ line\ %l:,%ZError:\ %m,%-C%.%#
+	" Capture Ledger warnings:
+	CompilerSet errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
+	" Skip all other lines:
+	CompilerSet errorformat+=%-G%.%#
+
+	" Check file syntax
+	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ %\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ %'
 endif
-
-" Capture Ledger errors (%-C ignores all lines between "While parsing..." and "Error:..."):
-CompilerSet errorformat=%EWhile\ parsing\ file\ \"%f\"\\,\ line\ %l:,%ZError:\ %m,%-C%.%#
-" Capture Ledger warnings:
-CompilerSet errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
-" Skip all other lines:
-CompilerSet errorformat+=%-G%.%#
-
-" Check file syntax
-exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ %:S'
-


### PR DESCRIPTION
Closes #99.

Using `ledger -f % source %` shouldn't be necessary and the value of the
second % is actually ignored, but it doesn't work without it. That bit
should be removed when the upstream bug is fixed:

https://github.com/ledger/ledger/issues/1682

The rest of this just clean up the detection of ledger vs. hledger now
that we support both so this only gets set when it will be expected to
work. While `hledger` does not have a comparable source function we can
accomplish something similar by testing if `print` returns errors and
just discarding the outut. This can be cleaned up if and when hledger
ever supports this natively:

https://github.com/simonmichael/hledger/issues/1115