### PR TITLE
syntax: highlight TODO and FIXME keywords

### DIFF
--- a/syntax/ledger.vim
+++ b/syntax/ledger.vim
@@ -99,6 +99,9 @@ syn region ledgerApply
 exe 'syn match ledgerApplyHead '.
   \ '/'.s:oe.'\%(^apply\s\+\)\@<=\S.*$/ contained'
 
+syntax keyword ledgerTodo FIXME TODO
+  \ contained containedin=ledgerComment,ledgerTransaction,ledgerTransactionMetadata,ledgerPostingMetadata
+
 highlight default link ledgerComment Comment
 highlight default link ledgerBlockComment Comment
 highlight default link ledgerBlockTest Comment
@@ -120,6 +123,7 @@ highlight default link ledgerPreDeclarationName Identifier
 highlight default link ledgerPreDeclarationDirective Type
 highlight default link ledgerDirective Type
 highlight default link ledgerOneCharDirective Type
+highlight default link ledgerTodo Todo
  
 " syncinc is easy: search for the first transaction.
 syn sync clear


### PR DESCRIPTION
Most other vim syntax definitions highlight these keywords for the user
to easily see where work is still required.

For example:

``` ledger
; FIXME: implement import from CSV file

1970-01-01 TODO unknown payee
    ; TODO: these postings are not complete yet
    Expenses:Food:Groceries             12.00 €  ; FIXME check amount
    Assets:Checking
```