### PR TITLE
Allow aligning on beginning of commodity

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -422,7 +422,9 @@ function! ledger#align_commodity() abort
     " Remove everything after the account name (including spaces):
     call setline('.', substitute(l:line, '\m^\s\+[^[:space:]].\{-}\zs\(\t\|  \).*$', '', ''))
     let pos = -1
-    if g:ledger_decimal_sep !=# ''
+    if g:ledger_align_commodity == 1
+      let pos = 0
+    elseif g:ledger_decimal_sep !=# ''
       " Find the position of the first decimal separator:
       let pos = s:decimalpos(rhs)
     endif
@@ -431,7 +433,7 @@ function! ledger#align_commodity() abort
       let pos = matchend(rhs, '\m\d[^[:space:]]*')
     endif
     " Go to the column that allows us to align the decimal separator at g:ledger_align_at:
-    if pos > 0
+    if pos >= 0
       call s:goto_col(g:ledger_align_at - pos - 1, 2)
     else
       call s:goto_col(g:ledger_align_at - strdisplaywidth(rhs) - 2, 2)

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -322,6 +322,10 @@ behaviour of the ledger filetype.
 
         let g:ledger_default_commodity = ''
 
+* Align on the commodity location instead of the amount
+
+	let g:ledger_align_commodity = 1
+
 * Flag that tells whether the commodity should be prepended or appended to the
   amount:
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -97,6 +97,10 @@ if !exists('g:ledger_align_at')
   let g:ledger_align_at = 60
 endif
 
+if !exists('g:ledger_align_commodity')
+  let g:ledger_align_commodity = 0
+endif
+
 if !exists('g:ledger_default_commodity')
   let g:ledger_default_commodity = ''
 endif

--- a/spec/align.vader
+++ b/spec/align.vader
@@ -19,3 +19,13 @@ Expect ledger:
   1970-01-01 Person
     Expenses                                                 $6.00
     Cash
+
+Execute (change default alignment):
+  let g:ledger_align_commodity = 0
+  let g:ledger_align_at = 40
+  LedgerAlignBuffer
+
+Expect ledger:
+  1970-01-01 Person
+    Expenses                           $6.00
+    Cash

--- a/spec/align.vader
+++ b/spec/align.vader
@@ -3,10 +3,19 @@ Given ledger:
     Expenses  $6.00
     Cash
 
-Execute:
+Execute (align buffer):
   LedgerAlignBuffer
 
 Expect ledger:
   1970-01-01 Person
     Expenses                                               $6.00
+    Cash
+
+Execute (align buffer on commodity):
+  let g:ledger_align_commodity = 1
+  LedgerAlignBuffer
+
+Expect ledger:
+  1970-01-01 Person
+    Expenses                                                 $6.00
     Cash


### PR DESCRIPTION
Feel free to suggest a better name than `g:ledger_align_commodity`, I don't think it's the best name. 

The idea behind this variable is to align on the first char of the amount, given that's the way I'd like to align things. 

For me personally, this would solve #106 