### PR TITLE
Support using `gq` (formatexpr) to align registers

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -540,7 +540,7 @@ function! ledger#align_amount_at_cursor() abort
   endif
 endf
 
-function! ledger#align_formatexpr(lnum, count)
+function! ledger#align_formatexpr(lnum, count) abort
   execute a:lnum . ',' . (a:lnum + a:count - 1) . 'call ledger#align_commodity()'
 endfunction
 

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -479,15 +479,7 @@ endf
 "      Expenses:Something                                 $-4,99
 "      Expenses:More                                     ($12,34 + $16,32)
 "
-function! ledger#align_commodity(...) abort
-  if a:0
-    " See :help 'formatexpr'
-    " a:1 -- v:lnum
-    " a:2 -- v:count
-    execute a:1 .. ',' .. (a:1 + a:2 - 1) .. 'call ledger#align_commodity()'
-    return
-  endif
-
+function! ledger#align_commodity() abort
   " Extract the part of the line after the account name (excluding spaces):
   let l:line = getline('.')
   let rhs = matchstr(l:line, '\m^\s\+[^;[:space:]].\{-}\(\t\|  \)\s*\zs.*$')
@@ -547,6 +539,10 @@ function! ledger#align_amount_at_cursor() abort
     exe 'normal! pa' . g:ledger_commodity_sep . g:ledger_default_commodity
   endif
 endf
+
+function! ledger#align_formatexpr(lnum, count)
+  execute a:lnum . ',' . (a:lnum + a:count - 1) . 'call ledger#align_commodity()'
+endfunction
 
 " Report generation {{{1
 

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -479,7 +479,15 @@ endf
 "      Expenses:Something                                 $-4,99
 "      Expenses:More                                     ($12,34 + $16,32)
 "
-function! ledger#align_commodity() abort
+function! ledger#align_commodity(...) abort
+  if a:0
+    " See :help 'formatexpr'
+    " a:1 -- v:lnum
+    " a:2 -- v:count
+    execute a:1 .. ',' .. (a:1 + a:2 - 1) .. 'call ledger#align_commodity()'
+    return
+  endif
+
   " Extract the part of the line after the account name (excluding spaces):
   let l:line = getline('.')
   let rhs = matchstr(l:line, '\m^\s\+[^;[:space:]].\{-}\(\t\|  \)\s*\zs.*$')

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -20,7 +20,7 @@ setl include=^!\\?include
 setl comments=b:;
 setl commentstring=;%s
 setl omnifunc=LedgerComplete
-setl formatexpr=ledger#align_commodity(v:lnum,v:count)
+setl formatexpr=ledger#align_formatexpr(v:lnum,v:count)
 
 if !exists('g:ledger_main')
   let g:ledger_main = '%'

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -21,6 +21,8 @@ setl comments=b:;
 setl commentstring=;%s
 setl omnifunc=LedgerComplete
 
+set formatexpr=ledger#align_commodity(v:lnum,v:count)
+
 if !exists('g:ledger_main')
   let g:ledger_main = '%'
 endif

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -20,8 +20,7 @@ setl include=^!\\?include
 setl comments=b:;
 setl commentstring=;%s
 setl omnifunc=LedgerComplete
-
-set formatexpr=ledger#align_commodity(v:lnum,v:count)
+setl formatexpr=ledger#align_commodity(v:lnum,v:count)
 
 if !exists('g:ledger_main')
   let g:ledger_main = '%'


### PR DESCRIPTION
This aims to plug the existing formatting code into vim's `formatexpr` option, which is a standard way to allow code formatters.