### PR TITLE
Add features to facilitate multi-currency alignment

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -453,6 +453,8 @@ endf
 
 " Return character position of decimal separator (multibyte safe)
 function! s:decimalpos(expr) abort
+  " Remove trailing comments
+  let l:expr = substitute(a:expr, '\v +;.*$', '', '')
   let pos = match(l:expr, '\v[' . g:ledger_decimal_sep . ']')
   if pos > 0
     let pos = strchars(a:expr[:pos]) - 1

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -455,10 +455,18 @@ endf
 function! s:decimalpos(expr) abort
   " Remove trailing comments
   let l:expr = substitute(a:expr, '\v +;.*$', '', '')
-  let pos = match(l:expr, '\v[' . g:ledger_decimal_sep . ']')
-  if pos > 0
-    let pos = strchars(a:expr[:pos]) - 1
-  endif
+  " Find first or last possible decimal separator candidate
+  if g:ledger_align_last
+    let pos = matchend(l:expr, '\v.*[' . g:ledger_decimal_sep . ']')
+    if pos > 0
+      let pos = strchars(a:expr[:pos]) + 1
+    endif
+  else
+    let pos = match(l:expr, '\v[' . g:ledger_decimal_sep . ']')
+    if pos > 0
+      let pos = strchars(a:expr[:pos]) - 1
+    endif
+  end
   return pos
 endf
 

--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -453,7 +453,7 @@ endf
 
 " Return character position of decimal separator (multibyte safe)
 function! s:decimalpos(expr) abort
-  let pos = match(a:expr, '\V' . g:ledger_decimal_sep)
+  let pos = match(l:expr, '\v[' . g:ledger_decimal_sep . ']')
   if pos > 0
     let pos = strchars(a:expr[:pos]) - 1
   endif

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -106,7 +106,8 @@ Tips and useful commands
   being the current line.
 
   The decimal separator can be set using `g:ledger_decimal_sep`. The default
-  value of `g:ledger_decimal_sep` is `'.'`.
+  value of `g:ledger_decimal_sep` is `'.'`. More than one possible character
+  may be specified and any matches will count, e.g. `'.,'`.
 
   See below for the recommended mappings.
 

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -109,6 +109,13 @@ Tips and useful commands
   value of `g:ledger_decimal_sep` is `'.'`. More than one possible character
   may be specified and any matches will count, e.g. `'.,'`.
 
+  By default the alignment is done on the first matching decimal separator.
+  This may be changed by setting `g:ledger_align_last` to `v:true`, in which
+  case the last possible decimal separater will be used. This is useful for
+  mixed-currency ledgers where decimal and thousands separators in different
+  currencies may clash and/or aligning on the right hand side of rate
+  convesions is desired.
+
   See below for the recommended mappings.
 
 * `:LedgerAlignBuffer`
@@ -324,6 +331,10 @@ behaviour of the ledger filetype.
 * Decimal separator:
 
         let g:ledger_decimal_sep = '.'
+
+* Specify alignment on first or last matching separator:
+
+	let g:ledger_align_last = v:false
 
 * Specify at which column decimal separators should be aligned:
 

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -94,6 +94,10 @@ if !exists('g:ledger_decimal_sep')
   let g:ledger_decimal_sep = '.'
 endif
 
+if !exists('g:ledger_align_last')
+  let g:ledger_align_last = v:false
+endif
+
 if !exists('g:ledger_align_at')
   let g:ledger_align_at = 60
 endif


### PR DESCRIPTION
Closes #79. The feature supplied is subtly different than the one requested since we don't really differentiate the different parts of a posting (unit, cost, total, etc.) but the most common cases are going to be either the first or last instance of thousand separators so this should provide more most use cases. Not covered would be multi-currency with conflicting thousands place and decimal separators where alignment of the first decimal separator is desired. If anybody wants that mode I would be willing to facilitate a PR, but I don't need it myself and so didn't put out the effort to cover it here.

Closes #106. That issue was mostly solved already by #107 and could probably have been closed. This does not *directly* address alignment on commodity, but it does provide another alternative that would make it possible to align even multiple commodities given that you could specify your commodity symbol(s) as decimal separators.
