### PR TITLE
fix: Return the correct indent when shiftwidth==0

### DIFF
--- a/indent/ledger.vim
+++ b/indent/ledger.vim
@@ -27,7 +27,7 @@ function GetLedgerIndent(...)
 
   if line =~# '^\s\+\S'
     " Lines that already are indented (→postings, sub-directives) keep their indentation.
-    return &shiftwidth
+    return shiftwidth()
   elseif line =~# '^\s*$'
     " Current line is empty, try to guess its type based on the previous line.
     if prev =~# '^\([[:digit:]~=]\|\s\+\S\)'
@@ -36,7 +36,7 @@ function GetLedgerIndent(...)
       " indented you will have to indent the first line following a
       " pre-declaration manually. This makes it easier to type long lists of
       " 'account' pre-declarations without sub-directives, for example.
-      return &shiftwidth
+      return shiftwidth()
     else
       return 0
     endif


### PR DESCRIPTION
Currently, when 'shiftwidth' is set to 0, GetLedgerIndent always returns
0, making it very ineffective.

But when 'shiftwidth' is set to 0, vim falls back to 'tabstop'. The help
entry of 'shiftwidth' recommends to use the shiftwidth function to get
the effective value of 'shiftwidth', which is what this fix does.
