### PR TITLE
feat: Account name completion using matchfuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Include the following let-statements somewhere in your `.vimrc` to modify the be
 
         let g:ledger_detailed_first = 1
 
+* If you want account completion based on fuzzy matching instead of the default sub-level completion, include the following line:
+
+        let g:ledger_fuzzy_account_completion = 1
+
 * By default vim will fold ledger transactions, leaving surrounding blank lines unfolded.
   You can use `g:ledger_fold_blanks` to hide blank lines following a transaction.
 
@@ -107,7 +111,7 @@ Omni completion is implemented for transactions descriptions and posting account
 
 ### Accounts
 
-Account names are matched by the start of every sub-level.
+By default, account names are matched by the start of every sub-level.
 When you insert an account name like this:
 
     Asse<C-X><C-O>
@@ -119,6 +123,16 @@ Go ahead and try something like:
     As:Ban:Che<C-X><C-O>
 
 When you have an account like this, 'Assets:Bank:Checking' should show up.
+
+If fuzzy matching based account completion is enabled, the matches are
+loaded based on string similarity and without regars for the sub-levels.
+
+In the previous example, with fuzzy matching enabled, you could load up
+matches by doing something like:
+
+    Chec<C-X><C-O>
+
+Notice that we did not need to write the initial account components.
 
 When you want to complete on a virtual transaction, it's currently best to keep the cursor in front of the closing bracket.
 Of course you can insert the closing bracket after calling the completion, too.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Go ahead and try something like:
 When you have an account like this, 'Assets:Bank:Checking' should show up.
 
 If fuzzy matching based account completion is enabled, the matches are
-loaded based on string similarity and without regars for the sub-levels.
+loaded based on string similarity and without regard for the sub-levels.
 
 In the previous example, with fuzzy matching enabled, you could load up
 matches by doing something like:

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -466,7 +466,7 @@ Go ahead and try something like:
 When you have an account like this, 'Assets:Bank:Checking' should show up.
 
 If fuzzy matching based account completion is enabled, the matches are
-loaded based on string similarity and without regars for the sub-levels.
+loaded based on string similarity and without regard for the sub-levels.
 
 In the previous example, with fuzzy matching enabled, you could load up
 matches by doing something like:

--- a/doc/ledger.txt
+++ b/doc/ledger.txt
@@ -325,6 +325,11 @@ behaviour of the ledger filetype.
 
         let g:ledger_fillstring = '    -'
 
+* If you want account completion based on fuzzy matching instead of the
+  default sub-level completion, include the following line:
+
+        let g:ledger_fuzzy_account_completion = 1
+
 * If you want the account completion to be sorted by level of detail/depth
   instead of alphabetical, include the following line:
 
@@ -447,8 +452,8 @@ Omni completion is currently implemented for account names only.
 
 ### Accounts
 
-Account names are matched by the start of every sub-level. When you
-insert an account name like this:
+By default, account names are matched by the start of every sub-level. When
+you insert an account name like this:
 
     Asse<C-X><C-O>
 
@@ -459,6 +464,16 @@ Go ahead and try something like:
     As:Ban:Che<C-X><C-O>
 
 When you have an account like this, 'Assets:Bank:Checking' should show up.
+
+If fuzzy matching based account completion is enabled, the matches are
+loaded based on string similarity and without regars for the sub-levels.
+
+In the previous example, with fuzzy matching enabled, you could load up
+matches by doing something like:
+
+    Chec<C-X><C-O>
+
+Notice that we did not need to write the initial account components.
 
 When you want to complete on a virtual transaction, it's currently best
 to keep the cursor in front of the closing bracket. Of course you can

--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -349,7 +349,9 @@ function! LedgerComplete(findstart, base) "{{{1
 
       call map(results, 'v:val[0]')
 
-      if g:ledger_detailed_first
+      if get(g:, "ledger_fuzzy_account_completion", 0)
+        let results = matchfuzzy(b:compl_cache.flat_accounts, a:base, {'matchseq':1})
+      elseif g:ledger_detailed_first
         let results = reverse(sort(results, 's:sort_accounts_by_depth'))
       else
         let results = sort(results)
@@ -398,12 +400,13 @@ unlet s:old s:new s:fun
 
 function! s:collect_completion_data() "{{{1
   let transactions = ledger#transactions()
-  let cache = {'descriptions': [], 'tags': {}, 'accounts': {}}
+  let cache = {'descriptions': [], 'tags': {}, 'accounts': {}, 'flat_accounts': []}
   if exists('g:ledger_accounts_cmd')
     let accounts = systemlist(g:ledger_accounts_cmd)
   else
     let accounts = ledger#declared_accounts()
   endif
+  let cache.flat_accounts = accounts
   if exists('g:ledger_descriptions_cmd')
     let cache.descriptions = systemlist(g:ledger_descriptions_cmd)
   endif


### PR DESCRIPTION
This commit adds an alternative way for completing account names to the pre-existing completion function. Here's an example:

```
commodity 1,000.00 USD

account Assets:Bank:Bofa:Checking
account Assets:Bank:Bofa:Savings
account Assets:Bank:Chase:Checking
account Assets:Bank:Chase:Savings
account Expenses:Coffee

2024-01-10  Buy Coffee
  Expenses:Coffee                 5.00 USD
  bofa█
       ,___________________________,
       | Assets:Bank:Bofa:Savings  |
       | Assets:Bank:Bofa:Checking |
       '---------------------------'
```

The older completion mechanism would need several keypresses before it can insert the Bofa:Checking account especially in a big ledger with a lot of accounts. I have found this fuzzy approach to be faster in my workflow and expect that other people might find it helpful too. 