### PR TITLE
fix: Improve errorformat for hledger

### DIFF
--- a/compiler/ledger.vim
+++ b/compiler/ledger.vim
@@ -33,7 +33,7 @@ if !b:is_hledger
 	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ ' . substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g') . '\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ ' . shellescape(expand(g:ledger_main))
 else
 	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ ' . substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g') . '\ check\ '. substitute(g:ledger_extra_options, ' ', '\\ ', 'g')
-	CompilerSet errorformat=%Ehledger:\ %trror:\ %f:%l:%c%.%#:,%-C\ \ \|\\s%#,%-C\%l\ \|%.%#,%-C\ \ \|\\s%#,%-C\ \ \|%p^,%+C%m,%-Z\\s%#
-	" Skip all other lines:
-	CompilerSet errorformat+=%-G%.%#
+	CompilerSet errorformat=hledger:\ %trror:\ %f:%l:%c:
+	CompilerSet errorformat+=hledger:\ %trror:\ %f:%l:
+	CompilerSet errorformat+=hledger:\ %trror:\ %f:%l-%.%#:
 endif


### PR DESCRIPTION
The original errorformat was specified as a multiline format followed by an "ignore non-matching lines format". I encountered some cases where this was problematic:

1. hledger errors have a lot of context spread across multiple lines. Matching everything with 1 multiline format causes vim to move all that information into a single error line which becomes very hard to read.
2. Removing non-matching lines makes it so that if an error is not recognized by efm then it is completely discarded. This can hide errors from the user. For example, in case of an unbalanced transaction hledger prints something like:
 ``` 
hledger: Error: <filename>:<line1>-<line2>: <line1> | <date>  <payee>
           |      <posting-line1>            <amount>
           |      <posting-line2>            <amount>
           |      <posting-line3>            <amount>
           |      ...
   This transaction is unbalanced.
   The real postings' sum should be 0 but is: <delta>
   Consider adjusting this entry's amounts, or adding missing postings.
   ```
   This error message does not match the old errorformat in the plugin.