### PR TITLE
Align currency with no decimal point correctly

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -510,7 +510,10 @@ function! ledger#align_commodity() abort
     endif
     if pos < 0
       " Find the position after the first digits
-      let pos = matchend(rhs, '\m\d[^[:space:]]*')
+      let pos = matchend(rhs, '\m\d[^[:space:]]*') - 1
+      if pos >= 0
+        let pos = strchars(rhs[:pos])
+      endif
     endif
     " Go to the column that allows us to align the decimal separator at g:ledger_align_at:
     if pos >= 0


### PR DESCRIPTION
The docs say:

> If an amount has no decimal point, the imaginary decimal point to the right of the least significant digit will align.

But this was not the behaviour I observed when calling `LedgerAlign`, there seemed to be an off by one error. For example, with `g:ledger_align_at = 50`, I would get:

```
2024-07-13 test
  Expense                                 £10000
  Expense                                     £10.10
  Assets
```

This PR subtracts one from pos if there is no decimal point to give:

```
2024-07-13 test
  Expense                                  £10000
  Expense                                     £10.10
  Assets
```

Which is what I expected.

I've made this PR with what corrects this for me, but I'm not familiar with the codebase so if I've overlooked something any feedback or advice is welcome.