### PR TITLE
fix: Add space escaping for `source` command on `makeprg` setting

### DIFF
--- a/compiler/ledger.vim
+++ b/compiler/ledger.vim
@@ -30,9 +30,21 @@ if !b:is_hledger
 	CompilerSet errorformat+=%tarning:\ \"%f\"\\,\ line\ %l:\ %m
 	" Skip all other lines:
 	CompilerSet errorformat+=%-G%.%#
-	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ ' . substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g') . '\ '.substitute(g:ledger_extra_options, ' ', '\\ ', 'g').'\ source\ ' . substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g')
+  exe 'CompilerSet makeprg='
+        \.substitute(g:ledger_bin, ' ', '\\ ', 'g')
+        \.'\ -f\ '
+        \.substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g')
+        \. '\ '
+        \.substitute(g:ledger_extra_options, ' ', '\\ ', 'g')
+        \.'\ source\ '
+        \.substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g')
 else
-	exe 'CompilerSet makeprg='.substitute(g:ledger_bin, ' ', '\\ ', 'g').'\ -f\ ' . substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g') . '\ check\ '. substitute(g:ledger_extra_options, ' ', '\\ ', 'g')
+  exe 'CompilerSet makeprg='
+        \.substitute(g:ledger_bin, ' ', '\\ ', 'g')
+        \.'\ -f\ '
+        \.substitute(shellescape(expand(g:ledger_main)), ' ', '\\ ', 'g')
+        \. '\ check\ '
+        \.substitute(g:ledger_extra_options, ' ', '\\ ', 'g')
 	CompilerSet errorformat=hledger:\ %trror:\ %f:%l:%c:
 	CompilerSet errorformat+=hledger:\ %trror:\ %f:%l:
 	CompilerSet errorformat+=hledger:\ %trror:\ %f:%l-%.%#:


### PR DESCRIPTION
## Problem
A path to my ledger file contains spaces and during nvim/vim start I see the error:

**`$ nvim "ledger file with spaces.ledger"`**
![image](https://github.com/user-attachments/assets/1fb3e78c-4455-4ab4-9bba-d683f048577a)

**`$ vim "ledger file with spaces.ledger"`**
![image](https://github.com/user-attachments/assets/845ba9e6-c05f-4523-9716-3dd1d09fd033)

Tested both `ledger` and `hledger` binaries, only `ledger` is affected

## Solution
Escaping `source` command argument with `substitute` (the same way it's done in #122) resolves the issue
Additionaly, I formatted the line with concatenation for better readability for both `ledger`/`hledger`

Tested on vim 9.1.785 and neovim v0.10.2
Probably fixes #144 