### PR TITLE
fix(foldtext): handle negative balance assertions (#165)

### DIFF
--- a/ftplugin/ledger.vim
+++ b/ftplugin/ledger.vim
@@ -222,7 +222,18 @@ let s:valreg = '\('.
              \ '\|'.
              \   '[,.][0-9]\+'.
              \ '\)'
-let s:optional_balance_assertion = '\(\s*=\s*'.s:cursym.'\s*'.s:valreg.'\)\?'
+let s:optsgn = '[+-]\?'
+let s:cursgn = '\('.
+             \   s:optsgn.
+             \   '\s*'.
+             \   s:cursym.
+             \ '\|'.
+             \   s:cursym.
+             \   '\s*'.
+             \   s:optsgn.
+             \ '\)'
+
+let s:optional_balance_assertion = '\(\s*=\s*'.s:cursgn.'\s*'.s:valreg.'\)\?'
 
 let s:rx_amount = s:valreg.
                 \ s:optional_balance_assertion.

--- a/test/vim-ledger-test.journal
+++ b/test/vim-ledger-test.journal
@@ -1,0 +1,29 @@
+; tests transactions for folds
+
+2025-01-01 test simple fold, no assertion, should read 100.10
+    io:income
+    assets:bank     £ 100.10
+
+2025-01-01 test positive assertion. should read 100.20
+    io:income
+    assets:bank     £ 100.20 = £ 200.10
+
+2025-01-01 no assertion, negative txn, should read -13
+    io:income
+    assets:bank     £ -13
+
+2025-01-01 test negative assertion. should read -400
+    io:income
+    assets:bank     £ -400  = £ -199.7
+
+2025-01-01 as above, sign and currency swapped. should read -400
+    io:income
+    assets:bank     £ -400  = - £199.7
+
+2025-01-01 test positive assert. should be 10
+    io:income
+    assets:bank     £ 10 = £ +12
+
+2025-01-01 test positive assert 2. should be 9
+    io:income
+    assets:bank     £ 9 = + £ 12


### PR DESCRIPTION
Further expand the regular expressions to match optional balance assertions to catch negative balance assertions.

Amounts can be signed with a negative symbol, or a positive one; the currency symbol and a sign symbol can be in either order: https://hledger.org/1.41/hledger.html#amounts

Add a test ledger under test/ to demonstrate some of the combinations.

Fixes: #165 