### PR TITLE
Use `WinClosed` to exit `:Reconcile`

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -982,7 +982,7 @@ function! ledger#reconcile(file, account, target_amount) abort
     augroup reconcile
       autocmd!
       execute "autocmd BufWritePost *.ldg,*.ledger call ledger#show_balance('" . l:file . "','" . a:account . "')"
-      autocmd BufWipeout <buffer> call <sid>finish_reconciling()
+      autocmd WinClosed <buffer> call <sid>finish_reconciling()
     augroup END
     " Add refresh shortcut
     execute "nnoremap <silent> <buffer> <c-l> :<c-u>call ledger#reconcile('"


### PR DESCRIPTION
I noticed `:Reconcile` never clears its autocommands, even after closing the quickfix window (as described in the docs). After some digging, the following events are not triggered when the quickfix window closes (with `:cclose` or `:q`):

- BufWipeout
- BufDelete
- BufUnload

The code here used `BufWipeout`, which would never trigger. The `WinClosed` event does fire when closing the quickfix window (both with `:cclose` and `:q`), so the teardown function for `:Reconcile` is triggered. Tested working on vim 9.1 and neovim 0.12.