### PR TITLE
fix: Make g:ledger_is_hledger set correctly

### DIFF
--- a/autoload/ledger.vim
+++ b/autoload/ledger.vim
@@ -32,10 +32,12 @@ elseif !executable(g:ledger_bin)
   echohl None
 endif
 
-if exists('g:ledger_bin') && !exists('g:ledger_is_hledger')
-  let g:ledger_is_hledger = g:ledger_bin =~# '.*hledger'
-else
-  let g:ledger_is_hledger = 0
+if !exists('g:ledger_is_hledger')
+  if exists('g:ledger_bin')
+    let g:ledger_is_hledger = g:ledger_bin =~# '.*hledger'
+  else
+    let g:ledger_is_hledger = 0
+  endif
 endif
 
 if !exists('g:ledger_main')


### PR DESCRIPTION
Close #175

Before commit:

|g:ledger_bin value|g:ledger_is_hledger in vimrc|g:ledger_is_hledger editing file|
|-|-|-|
|'hledger'|unset|1|
|'hledger'|v:false|0|
|'hledger'|v:true|0 (!)|
|'ledger'|unset|0|
|'ledger'|v:false|0|
|'ledger'|v:true|0 (!)|

After commit:

|g:ledger_bin value|g:ledger_is_hledger in vimrc|g:ledger_is_hledger editing file|
|-|-|-|
|'hledger'|unset|1|
|'hledger'|v:false|0|
|'hledger'|v:true|1|
|'ledger'|unset|0|
|'ledger'|v:false|0|
|'ledger'|v:true|1|